### PR TITLE
Adapt algo to 910B

### DIFF
--- a/example/ppo/train.py
+++ b/example/ppo/train.py
@@ -66,6 +66,9 @@ parser.add_argument(
 parser.add_argument(
     "--worker_num", type=int, default=2, help="Worker num (Default: 2)."
 )
+parser.add_argument(
+    "--graph_op_run", type=int, default=1, help="Run kernel by kernel (Default: 1)."
+)
 options, _ = parser.parse_known_args()
 
 
@@ -75,7 +78,7 @@ def train(episode=options.episode):
         context.set_context(device_target=options.device_target)
     if context.get_context("device_target") in ["CPU"]:
         context.set_context(enable_graph_kernel=True)
-    if context.get_context("device_target") in ["Ascend"]:
+    if context.get_context("device_target") in ["Ascend"] and options.graph_op_run:
         os.environ["GRAPH_OP_RUN"] = "1"
 
     compute_type = (

--- a/mindspore_rl/algorithm/maddpg/maddpg_trainer.py
+++ b/mindspore_rl/algorithm/maddpg/maddpg_trainer.py
@@ -187,29 +187,27 @@ class MADDPGTrainer(Trainer):
             duration += 1
             training_reward += rew_n.sum()
 
-            # ----------------------------------------- learner -------------------------------------------
-            if self.train_step % 100 == 0:
-                (
+        # ----------------------------------------- learner -------------------------------------------
+        if self.train_step % 100 == 0:
+            (
+                obs_n_batch,
+                act_n_batch,
+                rew_n_batch,
+                obs_next_n_batch,
+                done_n_batch,
+            ) = self.msrl.replay_buffer_sample()
+            agent_id = 0
+            while agent_id < self.num_agent:
+                loss += self._learn(
+                    agent_id,
                     obs_n_batch,
                     act_n_batch,
                     rew_n_batch,
                     obs_next_n_batch,
                     done_n_batch,
-                ) = self.msrl.replay_buffer_sample()
-                agent_id = 0
-                while agent_id < self.num_agent:
-                    loss += self._learn(
-                        agent_id,
-                        obs_n_batch,
-                        act_n_batch,
-                        rew_n_batch,
-                        obs_next_n_batch,
-                        done_n_batch,
-                    )
-                    agent_id += 1
+                )
+                agent_id += 1
 
-            if dones:
-                break
         return loss, training_reward, duration
 
     def trainable_variables(self):

--- a/mindspore_rl/algorithm/ppo/config.py
+++ b/mindspore_rl/algorithm/ppo/config.py
@@ -70,7 +70,7 @@ algorithm_config = {
     "policy_and_network": {"type": PPOPolicy, "params": policy_params},
     "collect_environment": {
         "number": 30,
-        "num_parallel": 30,
+        "num_parallel": 5,
         "type": GymEnvironment,
         "wrappers": [PyFuncWrapper, SyncParallelWrapper],
         "params": collect_env_params,

--- a/mindspore_rl/utils/soft_update.py
+++ b/mindspore_rl/utils/soft_update.py
@@ -79,8 +79,12 @@ class SoftUpdate(nn.Cell):
         return target_param
 
     def construct(self):
-        if not self.mod(self.steps, self.update_interval):
+        if self.update_interval == 1:
             updater = F.partial(self._update, self.factor)
             self.hyper_map(updater, self.behavior_params, self.target_params)
+        else:
+            if not self.mod(self.steps, self.update_interval):
+                updater = F.partial(self._update, self.factor)
+                self.hyper_map(updater, self.behavior_params, self.target_params)
         self.steps += 1
         return self.steps


### PR DESCRIPTION
1. 减少maddpg不必要控制流，如将learner部分从actor的循环中移出，删除if done，更新间隔为1的softupdate。性能提升明显从6.6ms/step -> 4.8ms/step
2. PPO算法修改环境并行线程数，ARM下30个线程性能较差更改为5。GE下kernel by kernel性能差于子图下沉端到端，修改为子图下沉执行。两项优化性能提升明显。环境线程修改性能从8.4ms/step->7.2ms/step
3. MAPPO适配910B